### PR TITLE
#23 update Spring Boot 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.openapitools.codegen.languages.KotlinClientCodegen.DateLibrary
-import org.openapitools.codegen.languages.KotlinClientCodegen.MOSHI_CODE_GEN
 
+// https://docs.spring.io/spring-boot/docs/3.0.x/gradle-plugin/reference/htmlsingle/
 plugins {
-	id("org.springframework.boot") version "2.7.5"
+	id("org.springframework.boot") version "3.0.1"
 	id("io.spring.dependency-management") version "1.0.15.RELEASE"
 	// https://github.com/etiennestuder/gradle-jooq-plugin#compatibility
-	id("nu.studer.jooq") version "8.0"
+	id("nu.studer.jooq") version "8.1"
 	id("org.openapi.generator") version "6.2.1"
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
@@ -20,10 +19,12 @@ repositories {
 	mavenCentral()
 }
 
+// https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/dependency-versions.html#appendix.dependency-versions
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-jooq")
-	// for "gradle-jooq-plugin" https://github.com/etiennestuder/gradle-jooq-plugin#compatibility
-	implementation("org.jooq:jooq:3.17.5")
+	// for "gradle-jooq-plugin" Minimum jOOQ 3.16+
+	// https://github.com/etiennestuder/gradle-jooq-plugin#compatibility
+	implementation("org.jooq:jooq")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.flywaydb:flyway-core")
@@ -41,8 +42,7 @@ dependencies {
 }
 
 jooq {
-	// version.set(dependencyManagement.importedProperties["jooq.version"])
-	version.set("3.17.5")
+	version.set(dependencyManagement.importedProperties["jooq.version"])
 	edition.set(nu.studer.gradle.jooq.JooqEdition.OSS)
 
 	configurations {


### PR DESCRIPTION
- test

```
$ ./gradlew test
Starting a Gradle Daemon, 1 incompatible and 2 stopped Daemons could not be reused, use --status for details

> Task :test
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2023-01-13T04:38:56.532+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-01-13T04:38:56.534+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2023-01-13T04:38:56.535+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-2 - Shutdown initiated...
2023-01-13T04:38:56.535+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-2 - Shutdown completed.
2023-01-13T04:38:56.537+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-3 - Shutdown initiated...
2023-01-13T04:38:56.537+09:00  INFO 17692 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-3 - Shutdown completed.

BUILD SUCCESSFUL in 7s
6 actionable tasks: 1 executed, 5 up-to-date
```

- run

```
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.0.1)

2023-01-13T04:36:13.560+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            : Executing query          : select "e"."id", "e"."category_id", "e"."member_id", "e"."name", "e"."price", "e"."memo", "e"."date", "e"."repeatable_month", "e"."repeatable_count", "c"."id", "c"."name", "c"."rank" from "public"."expenses" as "e" left outer join "public"."categories" as "c" on "e"."category_id" = "c"."id" order by "e"."id"
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            : Fetched result           : +----+-----------+---------+-----+-----+---------+----------+----------------+----------------+----+----+----+
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : |  id|category_id|member_id|name |price|memo     |date      |repeatable_month|repeatable_count|  id|name|rank|
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : +----+-----------+---------+-----+-----+---------+----------+----------------+----------------+----+----+----+
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : |   1|          1|        1|粉ミルク |  500|200gの缶のもの|2022-11-23|               1|               1|   1|食費  |   1|
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : |   2|          1|        1|おやつ  |  200|{null}   |2022-11-23|               0|               0|   1|食費  |   1|
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : |   3|          2|        2|おしゃぶり|  300|{null}   |2022-11-22|               0|               0|   2|消耗品 |   2|
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            :                          : +----+-----------+---------+-----+-----+---------+----------+----------------+----------------+----+----+----+
2023-01-13T04:36:13.565+09:00 DEBUG 16862 --- [nio-8089-exec-6] org.jooq.tools.LoggerListener            : Fetched row(s)           : 3
```